### PR TITLE
ResizeText

### DIFF
--- a/library.lua
+++ b/library.lua
@@ -1,1 +1,18 @@
 -- Make pull requests!
+function Render.ResizeText(text, maxSize, fontSize, font)
+    if (type(text) ~= "string" or type(maxSize) ~= "number" or type(fontSize) ~= "number") then return ""; end
+    local textSize = 0;
+    
+    ::resizeGoto::
+
+    if (font ~= nil) then
+        local ran = pcall(function() textSize = Render.CalcTextSize(text, fontSize, font); end);
+        if (not ran) then font = nil; goto resizeGoto; end
+    else
+        textSize = Render.CalcTextSize(text, fontSize)
+    end
+
+    if (textSize.x > maxSize) then text = string.sub(text, 0, #text - 1); goto resizeGoto; end
+
+    return text;
+end


### PR DESCRIPTION
Since there is no render clipping, you can use this to resize a string dynamically to fit an area.

Render.ResizeText(text, maxSize, fontSize, font);
Render.ResizeText(
string (Required), 
number (Required), 
number (Required),
font (Not Required)
);